### PR TITLE
Bug fix in factorial calculation Fixes:#{218}

### DIFF
--- a/maths/factorial.dart
+++ b/maths/factorial.dart
@@ -2,10 +2,14 @@ void main() {
   var n = 5;
   var fac = factorial(n);
   print("$n! = $fac"); /* output: 5! = 120 */
+
 }
 
 /* calculate factorial of n*/
-int factorial(var n) {
+int factorial(int n) {
+
+  assert(n >= 0);
+
   var fac = 1;
   for (int i = 2; i <= n; ++i) {
     fac *= i;


### PR DESCRIPTION
The error is that there is no factorial of a negative number. Therefore, it is necessary to set a test for the sign of the number from which we want to find the factorial. And one more mistake, the factorial cannot be calculated from real numbers, therefore, in my opinion, instead of var, it is necessary to put in the function int

# Welcome to Dart community

### **Describe your change:**

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?
* [ ] Add/Update/Fix test cases.


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Dart/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Dart files are placed inside an existing directory.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
