### PR TITLE
docs: Embed image directly in Time Complexity Graph section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ __Properties__
 
 ### Time-Complexity Graphs
 
-Comparing the complexity of sorting algorithms (Bubble Sort, Insertion Sort, Selection Sort)
+Comparing the complexity of sorting algorithms (Bubble Sort, Selection Sort and Insertion Sort)
 
-[Complexity Graphs](https://github.com/prateekiiest/Python/blob/master/sorts/sortinggraphs.png)
+![alt text][complexity-graph]
 
 [bubble-toptal]: https://www.toptal.com/developers/sorting-algorithms/bubble-sort
 [bubble-wiki]: https://en.wikipedia.org/wiki/Bubble_sort
@@ -156,6 +156,8 @@ Comparing the complexity of sorting algorithms (Bubble Sort, Insertion Sort, Sel
 
 [binary-wiki]: https://en.wikipedia.org/wiki/Binary_search_algorithm
 [binary-image]: https://upload.wikimedia.org/wikipedia/commons/f/f7/Binary_search_into_array.png
+
+[complexity-graph]: https://github.com/prateekiiest/Python/blob/master/sorts/sortinggraphs.png
 
 ----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Replaced the text link to the complexity graph with a direct image embed. This makes the graph visible without needing to click the link.

# Welcome to Dart community

### **Describe your change:**

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?
* [ ] Add/Update/Fix test cases.


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Dart/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Dart files are placed inside an existing directory.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
